### PR TITLE
Remove links to the tag.w3.org repository.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -140,8 +140,8 @@ You undoubtedly had reasons not to choose those alternatives, but reviewers and 
 Many important end-user problems have a history of failed and incomplete attempts to solve them.
 Look for and draw on those ideas when developing and explaining your own proposal.
 Link to all prior art in either
-your [considered alternatives](https://github.com/w3ctag/tag.w3.org/blob/main/explainers/template.md#considered-alternatives) section
-or your [references and acknowledgements](https://github.com/w3ctag/tag.w3.org/blob/main/explainers/template.md#references--acknowledgements).
+your [alternatives considered](https://github.com/w3ctag/explainer-explainer/blob/main/template.md#alternatives-considered) section
+or your [references and acknowledgements](https://github.com/w3ctag/explainer-explainer/blob/main/template.md#references--acknowledgements).
 
 ----
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/explainer-explainer/pull/20.html" title="Last updated on May 20, 2025, 6:12 PM UTC (ff1b068)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/explainer-explainer/20/450c150...jyasskin:ff1b068.html" title="Last updated on May 20, 2025, 6:12 PM UTC (ff1b068)">Diff</a>