### PR TITLE
Say that explainer contents should move into specifications.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -62,8 +62,8 @@ replace them with links to the relevant part of the spec.
 If you keep redundant text in the explainer,
 remember to update it as the specification changes.
 
-As your specification evolves,
-be sure to maintain the introduction, use cases, and examples
+As your specification and explainer evolve,
+be sure to maintain their introductions, use cases, and examples
 so that novices can still read them.
 This will make it easier for
 ["wide" reviewers](https://www.w3.org/guide/documentreview/#who-to-ask-for-wide-review)

--- a/index.bs
+++ b/index.bs
@@ -53,11 +53,14 @@ Follow the [tips](#tips) below to make your explainer as effective as possible.
 
 Once there is a reasonable amount of consensus on the approach and high-level design,
 use the explainer to guide spec writing.
-The parts of your explainer which document how developers should use the new API
-can be copied or moved into the specification.
-You should make sure the explainer remains useful either way:
-you can save some effort by replacing the moved sections with links into the relevant part of the spec,
-or you may prefer to edit the explainer as necessary to ensure it remains consistent.
+You can move or copy sections of your explainer directly into your specification
+or a [Group Note](https://www.w3.org/policies/process/#note-track)
+mentioned under the same [umbrella specification](https://www.w3.org/TR/spec-variability/#umbrella).
+Make sure that the explainer remains useful and accurate over time.
+If you move sections out of it,
+replace them with links to the relevant part of the spec.
+If you keep redundant text in the explainer,
+remember to update it as the specification changes.
 
 As your specification evolves,
 be sure to maintain the introduction, use cases, and examples

--- a/index.bs
+++ b/index.bs
@@ -53,8 +53,6 @@ Follow the [tips](#tips) below to make your explainer as effective as possible.
 
 Once there is a reasonable amount of consensus on the approach and high-level design,
 use the explainer to guide spec writing.
-Start your specification using whatever tool you prefer
-(e.g. [Bikeshed](https://speced.github.io/bikeshed/) or [Respec](https://respec.org/)).
 The parts of your explainer which document how developers should use the new API
 can be copied or moved into the specification.
 You should make sure the explainer remains useful either way:

--- a/index.bs
+++ b/index.bs
@@ -52,11 +52,19 @@ it should contain the following key components:
 Follow the [tips](#tips) below to make your explainer as effective as possible.
 
 Once there is a reasonable amount of consensus on the approach and high-level design,
-the explainer can be used to guide spec writing,
-by serving as a high-level overview of the feature to be specified and the user need it serves.
+use the explainer to guide spec writing.
+Start your specification using whatever tool you prefer
+(e.g. [Bikeshed](https://speced.github.io/bikeshed/) or [Respec](https://respec.org/)),
+and then move (don't copy) sections from your explainer into the specification.
+Be sure to leave links from the now-empty explainer sections
+to the specification sections that received their content.
 
-Once the spec is written and the feature is shipped,
-the explainer can then provide a basis for author-facing documentation of the new feature.
+As your specification evolves,
+be sure to maintain the introduction, use cases, and examples
+so that novices can still read them.
+This will make it easier for
+["wide" reviewers](https://www.w3.org/guide/documentreview/#who-to-ask-for-wide-review)
+to do their reviews.
 
 # Examples of Good Explainers # {#good-explainers}
 

--- a/index.bs
+++ b/index.bs
@@ -55,9 +55,11 @@ Once there is a reasonable amount of consensus on the approach and high-level de
 use the explainer to guide spec writing.
 Start your specification using whatever tool you prefer
 (e.g. [Bikeshed](https://speced.github.io/bikeshed/) or [Respec](https://respec.org/)).
-You may want to move (not copy) sections from your explainer into the specification as you write it.
-If you do, be sure to leave links from the now-empty explainer sections
-to the specification sections that received their content.
+The parts of your explainer which document how developers should use the new API
+can be copied or moved into the specification.
+You should make sure the explainer remains useful either way:
+you can save some effort by replacing the moved sections with links into the relevant part of the spec,
+or you may prefer to edit the explainer as necessary to ensure it remains consistent.
 
 As your specification evolves,
 be sure to maintain the introduction, use cases, and examples

--- a/index.bs
+++ b/index.bs
@@ -54,9 +54,9 @@ Follow the [tips](#tips) below to make your explainer as effective as possible.
 Once there is a reasonable amount of consensus on the approach and high-level design,
 use the explainer to guide spec writing.
 Start your specification using whatever tool you prefer
-(e.g. [Bikeshed](https://speced.github.io/bikeshed/) or [Respec](https://respec.org/)),
-and then move (don't copy) sections from your explainer into the specification.
-Be sure to leave links from the now-empty explainer sections
+(e.g. [Bikeshed](https://speced.github.io/bikeshed/) or [Respec](https://respec.org/)).
+You may want to move (not copy) sections from your explainer into the specification as you write it.
+If you do, be sure to leave links from the now-empty explainer sections
 to the specification sections that received their content.
 
 As your specification evolves,


### PR DESCRIPTION
This is meant to fix #6. Also see #19 for some frustration that I used as input.

It's still fairly rough, and I'm expecting to refine it based on feedback. @slightlyoff and @alice, you're likely to have comments.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/explainer-explainer/pull/25.html" title="Last updated on Jul 2, 2025, 6:28 AM UTC (9cd953d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/explainer-explainer/25/7aeea94...jyasskin:9cd953d.html" title="Last updated on Jul 2, 2025, 6:28 AM UTC (9cd953d)">Diff</a>