### PR TITLE
Fix two pubrules errors: metadata and an editor outside the TAG

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,7 @@ indent_size = 4
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,3 @@ indent_size = 4
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
-
-[*.yml]
-indent_style = space
-indent_size = 2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
-      - uses: w3c/spec-prod@pubrules-profiles-patch
+      - uses: w3c/spec-prod@v2
         with:
           BUILD_FAIL_ON: warning
           GH_PAGES_BRANCH: gh-pages
@@ -21,4 +21,3 @@ jobs:
             status: NOTE
             metadata order: *, !*
             metadata include: Participate no, Feedback yes
-          VALIDATE_PUBRULES: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
-      - uses: w3c/spec-prod@v2
+      - uses: w3c/spec-prod@pubrules-profiles-patch
         with:
           BUILD_FAIL_ON: warning
           GH_PAGES_BRANCH: gh-pages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,3 +20,5 @@ jobs:
           W3C_BUILD_OVERRIDE: |
             status: NOTE
             metadata order: *, !*
+            metadata include: Participate no, Feedback yes
+          VALIDATE_PUBRULES: true

--- a/index.bs
+++ b/index.bs
@@ -7,9 +7,9 @@ Group: tag
 Repository: w3ctag/explainer-explainer
 URL: https://w3ctag.github.io/explainer-explainer/
 TR: https://www.w3.org/TR/explainer-explainer/
-Editor: Daniel Appelquist, w3cid 35086, Invited Expert
 Editor: Matthew Tylee Atkinson, w3cid 68793, Samsung https://www.samsung.com
 Editor: Jeffrey Yasskin, w3cid 72192, Google https://google.com, jyasskin@google.com
+Former Editor: Daniel Appelquist, w3cid 35086, Invited Expert
 Complain About: accidental-2119 yes, missing-example-ids yes
 Markup Shorthands: markdown yes, css no
 Assume Explicit For: yes


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/explainer-explainer/pull/28.html" title="Last updated on Jul 2, 2025, 7:16 AM UTC (fae189f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/explainer-explainer/28/6e6adaf...jyasskin:fae189f.html" title="Last updated on Jul 2, 2025, 7:16 AM UTC (fae189f)">Diff</a>